### PR TITLE
Add hybrid retrieval and preprocessing improvements

### DIFF
--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -3,7 +3,7 @@ System prompt für den RAG AI agent.
 """
 
 # System prompt for the RAG agent
-RAG_SYSTEM_PROMPT = """Du bist ein KI-Assistent für die Firma „Wunsch Öle“.  
+RAG_SYSTEM_PROMPT = """Du bist ein KI-Assistent für die Firma „Wunsch Öle“.
 Deine einzige Wissensquelle sind die in der Wissensdatenbank gespeicherten PDF-Datenblätter (Produktspezifikationen).  
 Ignoriere jegliches allgemeines Vorwissen aus deinem Training, falls es nicht explizit durch Datenbank-Treffer belegt ist.
 
@@ -33,8 +33,11 @@ Ignoriere jegliches allgemeines Vorwissen aus deinem Training, falls es nicht ex
    • Verwende nur die Maßeinheiten, Formulierungen und Zahlen, die im Datenblatt vorkommen.  
    • Gib bei Mischungsverhältnissen, Temperaturen, Viskositäten usw. die Originalwerte wieder.
 
-6. **Zielgruppe**  
+6. **Zielgruppe**
    Die Antworten richten sich an Service-Mitarbeiter von Wunsch Öle, die Kundenfragen schnell und korrekt beantworten wollen. Verzichte auf Marketingfloskeln.
+
+7. **Query Expansion**
+   Formuliere Suchanfragen intern so, dass auch Synonyme und alternative Schreibweisen gefunden werden können (z.B. "mg/l" und "mg pro Liter").
 
 > Befolge diese Regeln strikt. Jede Abweichung gilt als Fehler.
 """

--- a/document_processing/chunker.py
+++ b/document_processing/chunker.py
@@ -1,8 +1,6 @@
 # run: streamlit run app.py
 
-import os
 from typing import List
-from pathlib import Path
 
 
 class TextChunker:
@@ -10,7 +8,7 @@ class TextChunker:
     Simple text chunker that splits documents into manageable pieces.
     """
 
-    def __init__(self, chunk_size: int = 1000, chunk_overlap: int = 200):
+    def __init__(self, chunk_size: int = 2000, chunk_overlap: int = 400):
         """
         Initialize the chunker with size and overlap settings.
 

--- a/document_processing/reranker.py
+++ b/document_processing/reranker.py
@@ -1,0 +1,25 @@
+from typing import List, Dict, Any
+
+try:
+    from sentence_transformers import CrossEncoder
+except Exception:  # noqa: S110
+    CrossEncoder = None
+
+
+class CrossEncoderReranker:
+    """Optional cross-encoder reranking using MiniLM."""
+
+    def __init__(self, model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"):
+        if CrossEncoder is None:
+            self.model = None
+        else:
+            self.model = CrossEncoder(model_name)
+
+    def rerank(self, query: str, results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if not self.model or not results:
+            return results
+        pairs = [(query, r["content"]) for r in results]
+        scores = self.model.predict(pairs)
+        for r, s in zip(results, scores):
+            r["rerank_score"] = float(s)
+        return sorted(results, key=lambda x: x.get("rerank_score", 0), reverse=True)

--- a/document_processing/utils.py
+++ b/document_processing/utils.py
@@ -1,0 +1,16 @@
+import re
+
+
+def preprocess_text(text: str) -> str:
+    """Normalize units and remove soft hyphen breaks."""
+    if not text:
+        return text
+    # Normalize mg/l and N/mm² with optional spaces or narrow spaces
+    text = re.sub(r"mg\s*/\s*l", "mg/l", text, flags=re.IGNORECASE)
+    text = re.sub(r"N\s*/\s*mm²", "N/mm²", text)
+
+    # Remove soft hyphen or hyphen at line breaks
+    text = text.replace("\u00ad", "")
+    text = re.sub(r"-\n\s*", "", text)
+
+    return text

--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -3,8 +3,6 @@ Unit tests for the text chunker module.
 """
 import os
 import sys
-import pytest
-from pathlib import Path
 
 # Add parent directory to path to allow relative imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -22,8 +20,8 @@ class TestTextChunker:
         Test that TextChunker initializes with default values.
         """
         chunker = TextChunker()
-        assert chunker.chunk_size == 1000
-        assert chunker.chunk_overlap == 200
+        assert chunker.chunk_size == 2000
+        assert chunker.chunk_overlap == 400
     
     def test_init_with_custom_values(self):
         """
@@ -49,7 +47,7 @@ class TestTextChunker:
         """
         Test chunking text that is shorter than chunk_size.
         """
-        chunker = TextChunker(chunk_size=1000, chunk_overlap=200)
+        chunker = TextChunker(chunk_size=2000, chunk_overlap=400)
         text = "This is a short text."
         chunks = chunker.chunk_text(text)
         


### PR DESCRIPTION
## Summary
- normalize units and remove soft hyphens during ingestion
- increase chunk size defaults to ~2000 chars with 20% overlap
- add keyword search and CrossEncoder reranking for RAG matches
- update prompt with query expansion rule
- adjust tests for new chunk defaults

## Testing
- `pytest -q` *(fails: OpenAI/Supabase requests blocked; chunker tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_685985ef29948332b30c670b9848f6aa