### PR TITLE
Adjust logging level for smoother uploads

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -10,7 +10,8 @@ import os
 # Logging
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
+# Reduce verbosity by logging only informational messages and above
+logging.basicConfig(level=logging.INFO)
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 


### PR DESCRIPTION
## Summary
- lower default logging level in the Streamlit app to INFO

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'postgrest')*

------
https://chatgpt.com/codex/tasks/task_e_685a50a3f6c483328ebdc1ea1c7e9d95